### PR TITLE
feat(web): vollständiger Dark Mode mit Theme-Auswahl im Account-Menü

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fi-go",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fi-go",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "workspaces": [
         "projects/*"
       ],

--- a/projects/web/index.html
+++ b/projects/web/index.html
@@ -9,6 +9,18 @@
   <!-- Prevents white flash before CSS loads -->
   <style>html, body { margin: 0; background-color: #E5173F; }</style>
 
+  <!-- No-FOUC theme bootstrap: applies .dark class before first paint -->
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem('fi-go.theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var dark = stored === 'dark' || ((stored === null || stored === 'system') && prefersDark);
+        if (dark) document.documentElement.classList.add('dark');
+      } catch (e) { /* ignore */ }
+    })();
+  </script>
+
   <!-- Icons -->
   <link rel="icon" href="/favicon.ico" sizes="48x48">
   <link rel="icon" href="/icon-512.svg" sizes="any" type="image/svg+xml">

--- a/projects/web/src/App.tsx
+++ b/projects/web/src/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
       <BreaksDrawer breaks={breaks} onAddBreak={addBreak} onRemoveBreak={removeBreak} startTime={startTime} desktopMode />
       <Button
         onClick={clockOut}
-        className="rounded-full bg-[#E5173F] text-white hover:bg-[#cc1538] shadow-[0_0_14px_rgba(229,23,63,0.38)] border-0"
+        className="rounded-full bg-primary text-white hover:brightness-110 shadow-[0_0_14px_hsl(var(--primary)/0.38)] border-0"
       >
         <LogOut className="mr-2 h-4 w-4" /> Feierabend
       </Button>

--- a/projects/web/src/components/features/breaks/BreaksTrigger.tsx
+++ b/projects/web/src/components/features/breaks/BreaksTrigger.tsx
@@ -15,7 +15,7 @@ export const BreaksTrigger = forwardRef<HTMLButtonElement, BreaksTriggerProps>(
         <Button
           ref={ref}
           variant="ghost"
-          className="rounded-full border border-[#E5173F] text-[#E5173F] hover:bg-[#E5173F]/10 hover:text-[#E5173F]"
+          className="rounded-full border border-primary text-primary hover:bg-primary/10 hover:text-primary"
           {...props}
         >
           <Coffee className="mr-2 h-4 w-4" /> Pausen

--- a/projects/web/src/components/features/timer/BreakTooltip.tsx
+++ b/projects/web/src/components/features/timer/BreakTooltip.tsx
@@ -18,8 +18,8 @@ export function BreakTooltip({ x, y, item }: BreakTooltipProps) {
         transform: 'translate(-50%, -50%)',
       }}
     >
-      <div className="bg-white/95 backdrop-blur-sm shadow-lg border border-border/30 rounded-xl px-2.5 py-1.5 text-center whitespace-nowrap">
-        <p className="text-[12px] font-semibold tabular-nums text-foreground leading-none">
+      <div className="bg-popover/95 backdrop-blur-sm shadow-lg border border-border/50 rounded-xl px-2.5 py-1.5 text-center whitespace-nowrap">
+        <p className="text-[12px] font-semibold tabular-nums text-popover-foreground leading-none">
           {format(item.wallStart, 'HH:mm')} – {format(item.wallEnd, 'HH:mm')}
         </p>
         {item.kind === 'legal' && (

--- a/projects/web/src/components/features/timer/TimerRing.tsx
+++ b/projects/web/src/components/features/timer/TimerRing.tsx
@@ -84,7 +84,7 @@ export function TimerRing({
         })}
 
         {/* Work/Over-Segmente mit Drop-Shadow für Tiefe */}
-        <g style={{ filter: 'drop-shadow(0 0 5px rgba(229,23,63,0.28))' }}>
+        <g style={{ filter: 'drop-shadow(0 0 5px hsl(var(--primary) / 0.28))' }}>
           {segments.filter(s => s.kind !== 'break').map((seg, i) => {
             const a0 = minToAngle(seg.start, ringMaxMin);
             const a1 = minToAngle(seg.end, ringMaxMin);
@@ -126,7 +126,7 @@ export function TimerRing({
             cy={tipPoint.y}
             r={6}
             fill={RING_COLORS.work}
-            style={{ filter: 'drop-shadow(0 0 7px #E5173F)' }}
+            style={{ filter: 'drop-shadow(0 0 7px hsl(var(--primary)))' }}
           />
         )}
 

--- a/projects/web/src/components/layout/ProfileMenu.tsx
+++ b/projects/web/src/components/layout/ProfileMenu.tsx
@@ -1,15 +1,30 @@
 import type { User } from 'firebase/auth';
-import { LogOut, ChevronDown, ExternalLink, Bug, Info } from 'lucide-react';
+import {
+  LogOut,
+  ChevronDown,
+  ExternalLink,
+  Bug,
+  Info,
+  Sun,
+  Moon,
+  MonitorSmartphone,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { UserAvatar } from '@/components/ui/user-avatar';
 import { SURFACE_CLASS } from '@/components/ui/surface-classes';
 import { Eyebrow } from '@/components/ui/eyebrow';
+import { useTheme, type ThemeMode } from '@/hooks/use-theme';
 import { cn } from '@/lib/utils';
 
 interface ProfileMenuProps {
@@ -18,7 +33,16 @@ interface ProfileMenuProps {
   onOpenAbout: () => void;
 }
 
+const MODE_ICON: Record<ThemeMode, typeof Sun> = {
+  system: MonitorSmartphone,
+  light: Sun,
+  dark: Moon,
+};
+
 export function ProfileMenu({ user, onLogout, onOpenAbout }: ProfileMenuProps) {
+  const { mode, setMode } = useTheme();
+  const ActiveModeIcon = MODE_ICON[mode];
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -50,6 +74,47 @@ export function ProfileMenu({ user, onLogout, onOpenAbout }: ProfileMenuProps) {
                 <span className="font-medium text-xs">Abmelden</span>
               </DropdownMenuItem>
             )}
+          </div>
+
+          <DropdownMenuSeparator className="my-2 opacity-40" />
+
+          <div className="px-1">
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex items-center gap-3 px-3 py-2.5 text-sm text-muted-foreground focus:text-foreground focus:bg-accent/50 rounded-xl transition-colors cursor-pointer">
+                <ActiveModeIcon className="h-4 w-4 shrink-0" />
+                <span className="font-medium">Erscheinungsbild</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                className={cn(SURFACE_CLASS.popover, 'w-44 p-2 z-50')}
+              >
+                <DropdownMenuRadioGroup
+                  value={mode}
+                  onValueChange={(value) => setMode(value as ThemeMode)}
+                >
+                  <DropdownMenuRadioItem
+                    value="system"
+                    className="flex items-center gap-3 pl-3 pr-9 py-2.5 text-sm text-muted-foreground focus:text-foreground focus:bg-accent/50 rounded-xl transition-colors cursor-pointer"
+                  >
+                    <MonitorSmartphone className="h-4 w-4 shrink-0" />
+                    <span className="font-medium">System</span>
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem
+                    value="light"
+                    className="flex items-center gap-3 pl-3 pr-9 py-2.5 text-sm text-muted-foreground focus:text-foreground focus:bg-accent/50 rounded-xl transition-colors cursor-pointer"
+                  >
+                    <Sun className="h-4 w-4 shrink-0" />
+                    <span className="font-medium">Hell</span>
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem
+                    value="dark"
+                    className="flex items-center gap-3 pl-3 pr-9 py-2.5 text-sm text-muted-foreground focus:text-foreground focus:bg-accent/50 rounded-xl transition-colors cursor-pointer"
+                  >
+                    <Moon className="h-4 w-4 shrink-0" />
+                    <span className="font-medium">Dunkel</span>
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           </div>
 
           <DropdownMenuSeparator className="my-2 opacity-40" />

--- a/projects/web/src/components/ui/app-bar-shell.tsx
+++ b/projects/web/src/components/ui/app-bar-shell.tsx
@@ -11,9 +11,8 @@ export function AppBarShell({ className, children, ...props }: HTMLAttributes<HT
     <header
       className={cn(
         'h-14 shrink-0 w-full flex items-center px-4 sm:px-6',
-        'bg-white/80 backdrop-blur-xl border-b border-white/70',
+        'bg-background/80 backdrop-blur-xl border-b border-border/70',
         'sticky top-0 z-50 shadow-sm',
-        'dark:bg-neutral-900/70 dark:border-neutral-800/80',
         className,
       )}
       {...props}

--- a/projects/web/src/components/ui/bottom-bar-action.tsx
+++ b/projects/web/src/components/ui/bottom-bar-action.tsx
@@ -9,9 +9,6 @@ interface BottomBarActionProps extends Omit<ComponentProps<typeof Button>, 'chil
 
 /**
  * Vertikaler Icon+Label-Button für die mobile BottomBar (Feierabend, Pausen-Trigger, …).
- * Kapselt das `flex-col gap-1 h-auto py-2.5 px-5 text-[#999]`-Pattern, das vorher
- * in App.tsx und BreaksTrigger 1:1 kopiert war.
- *
  * Forwarded Ref, damit Radix/Vaul-`asChild`-Trigger funktionieren.
  */
 export const BottomBarAction = forwardRef<HTMLButtonElement, BottomBarActionProps>(
@@ -22,7 +19,7 @@ export const BottomBarAction = forwardRef<HTMLButtonElement, BottomBarActionProp
         variant="ghost"
         className={cn(
           'flex flex-col gap-1 h-auto py-2.5 px-5',
-          'text-[#999] hover:text-[#E5173F] hover:bg-transparent',
+          'text-muted-foreground hover:text-primary hover:bg-transparent',
           className,
         )}
         {...props}

--- a/projects/web/src/components/ui/logo.tsx
+++ b/projects/web/src/components/ui/logo.tsx
@@ -1,7 +1,7 @@
 interface LogoProps {
   /** Renderhöhe in Pixel. Breite skaliert proportional. */
   height?: number
-  /** SVG-Farbwert. Standard: Primärfarbe #E5173F. */
+  /** SVG-Farbwert. Standard: Primärfarb-Token (passt sich Light/Dark an). */
   color?: string
   className?: string
 }
@@ -12,7 +12,7 @@ interface LogoProps {
  * Monoline-Schrift auf 28-Einheiten-Grid, stroke-width 2.4, rounded caps.
  * Buchstaben: f i – g o   (alle Kleinbuchstaben, geometric-sans Stil)
  */
-export function Logo({ height = 28, color = '#E5173F', className, ...props }: LogoProps) {
+export function Logo({ height = 28, color = 'hsl(var(--primary))', className, ...props }: LogoProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/projects/web/src/components/ui/submit-button.tsx
+++ b/projects/web/src/components/ui/submit-button.tsx
@@ -7,16 +7,15 @@ type Variant = 'primary' | 'outline';
 const VARIANT_CLASS: Record<Variant, string> = {
   primary:
     'bg-primary text-white ' +
-    'hover:brightness-110 hover:shadow-[0_6px_20px_oklch(0.510_0.230_22_/_0.35)] ' +
+    'hover:brightness-110 hover:shadow-[0_6px_20px_hsl(var(--primary)/0.35)] ' +
     'active:scale-[0.98] active:brightness-95 ' +
     'disabled:opacity-40 disabled:cursor-not-allowed disabled:scale-100 disabled:shadow-none',
   outline:
-    'border border-[#E5173F] bg-white text-[#E5173F] ' +
-    'shadow-[0_2px_10px_rgba(0,0,0,0.07)] ' +
-    'hover:bg-[#E5173F]/5 ' +
+    'border border-primary bg-card text-primary ' +
+    'shadow-[0_2px_10px_hsl(var(--foreground)/0.07)] ' +
+    'hover:bg-primary/5 ' +
     'active:scale-[0.98] ' +
-    'disabled:opacity-40 disabled:cursor-not-allowed ' +
-    'dark:bg-neutral-900 dark:border-primary dark:text-primary dark:hover:bg-primary/10',
+    'disabled:opacity-40 disabled:cursor-not-allowed',
 };
 
 interface SubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/projects/web/src/components/ui/surface-classes.ts
+++ b/projects/web/src/components/ui/surface-classes.ts
@@ -8,14 +8,12 @@ export type SurfaceVariant = 'card' | 'bar' | 'popover' | 'toast';
 export const SURFACE_CLASS: Record<SurfaceVariant, string> = {
   // Info-Card / Saldo-Card
   card:
-    'rounded-2xl bg-white/80 backdrop-blur-xl border border-white/90 ' +
-    'shadow-[0_8px_32px_-6px_oklch(0.510_0.230_22_/_0.14),0_2px_8px_-2px_oklch(0_0_0_/_0.07)] ' +
-    'dark:bg-neutral-900/55 dark:border-neutral-700/60',
+    'rounded-2xl bg-card/80 backdrop-blur-xl border border-border ' +
+    'shadow-[0_8px_32px_-6px_hsl(var(--primary)/0.14),0_2px_8px_-2px_hsl(var(--foreground)/0.07)]',
 
   // Mobile Bottom-Bar / App-Bar
   bar:
-    'rounded-2xl bg-white/80 backdrop-blur-xl border border-[rgba(229,23,63,0.1)] ' +
-    'dark:bg-neutral-900/70 dark:border-neutral-800/80',
+    'rounded-2xl bg-card/80 backdrop-blur-xl border border-primary/10',
 
   // Popover / Dropdown-Menu
   popover:
@@ -23,5 +21,5 @@ export const SURFACE_CLASS: Record<SurfaceVariant, string> = {
 
   // Toast
   toast:
-    'rounded-2xl bg-white/80 backdrop-blur-xl border border-white/20 shadow-lg',
+    'rounded-2xl bg-card/80 backdrop-blur-xl border border-border/50 shadow-lg',
 };

--- a/projects/web/src/components/ui/text-field.tsx
+++ b/projects/web/src/components/ui/text-field.tsx
@@ -3,12 +3,11 @@ import { cn } from '@/lib/utils';
 import { Eyebrow } from './eyebrow';
 
 const FIELD_BASE_CLASS =
-  'w-full h-13 rounded-2xl border border-[rgba(229,23,63,0.2)] bg-white/90 ' +
-  'shadow-[0_2px_10px_rgba(0,0,0,0.07)] outline-none ' +
+  'w-full h-13 rounded-2xl border border-primary/20 bg-card/90 ' +
+  'shadow-[0_2px_10px_hsl(var(--foreground)/0.07)] outline-none ' +
   'placeholder:text-muted-foreground/40 ' +
   'transition-all duration-150 ' +
-  'focus:border-[rgba(229,23,63,0.4)] focus:ring-3 focus:ring-primary/10 focus:bg-white ' +
-  'dark:bg-neutral-900 dark:border-neutral-800 dark:focus:bg-neutral-950';
+  'focus:border-primary/40 focus:ring-3 focus:ring-primary/10 focus:bg-card';
 
 interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   label?: string;

--- a/projects/web/src/hooks/ThemeProvider.tsx
+++ b/projects/web/src/hooks/ThemeProvider.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  ThemeContext,
+  THEME_STORAGE_KEY,
+  type ResolvedTheme,
+  type ThemeMode,
+} from './theme-context';
+
+const MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+function readStoredMode(): ThemeMode {
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
+  } catch {
+    // localStorage kann in privatem Modus / SSR fehlen — Default greifen
+  }
+  return 'system';
+}
+
+function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia(MEDIA_QUERY).matches;
+}
+
+function resolveMode(mode: ThemeMode): ResolvedTheme {
+  if (mode === 'system') return systemPrefersDark() ? 'dark' : 'light';
+  return mode;
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  if (resolved === 'dark') root.classList.add('dark');
+  else root.classList.remove('dark');
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredMode());
+  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveMode(readStoredMode()));
+
+  useEffect(() => {
+    const next = resolveMode(mode);
+    setResolved(next);
+    applyTheme(next);
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode !== 'system') return;
+    const mq = window.matchMedia(MEDIA_QUERY);
+    const handler = (e: MediaQueryListEvent) => {
+      const next: ResolvedTheme = e.matches ? 'dark' : 'light';
+      setResolved(next);
+      applyTheme(next);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [mode]);
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next);
+    try {
+      if (next === 'system') localStorage.removeItem(THEME_STORAGE_KEY);
+      else localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // ignorieren
+    }
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ mode, resolved, setMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/projects/web/src/hooks/theme-context.ts
+++ b/projects/web/src/hooks/theme-context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'fi-go.theme';
+
+export interface ThemeContextType {
+  /** Vom Nutzer gewählter Modus (inkl. „system"). */
+  mode: ThemeMode;
+  /** Effektiv aktiver Modus nach Auflösung von „system" gegen `prefers-color-scheme`. */
+  resolved: ResolvedTheme;
+  setMode: (mode: ThemeMode) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/projects/web/src/hooks/use-theme.ts
+++ b/projects/web/src/hooks/use-theme.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ThemeContext } from './theme-context';
+
+export type { ThemeMode, ResolvedTheme, ThemeContextType } from './theme-context';
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/projects/web/src/index.css
+++ b/projects/web/src/index.css
@@ -70,6 +70,8 @@
     --border: 240 6% 90%;
     --input: 240 6% 90%;
     --ring: 348 82% 49%;              /* primär */
+    --ring-over: 25 95% 53%;          /* Timer-Overtime-Bogen ≈ #F97316 */
+    --ring-track: oklch(0.928 0.006 264); /* Timer-Track (leerer Bogen) */
     --radius: 0.5rem;
   }
 
@@ -93,6 +95,8 @@
     --border: 240 5% 18%;
     --input: 240 5% 18%;
     --ring: 348 80% 65%;
+    --ring-over: 25 90% 60%;          /* Overtime-Bogen, etwas heller für dunklen Track */
+    --ring-track: oklch(0.28 0.008 264); /* Track im Dark — gedämpft, klar sichtbar */
   }
 
   * {
@@ -105,6 +109,14 @@
       radial-gradient(ellipse 80% 60% at 85% 0%,   oklch(0.965 0.030 30  / 0.9), transparent 60%),
       radial-gradient(ellipse 70% 55% at 10% 100%,  oklch(0.970 0.025 355 / 0.8), transparent 60%),
       linear-gradient(135deg, oklch(0.994 0.006 30) 0%, oklch(0.984 0.012 22) 55%, oklch(0.976 0.018 355) 100%);
+    background-attachment: fixed;
+  }
+
+  .dark body {
+    background:
+      radial-gradient(ellipse 80% 60% at 85% 0%,   oklch(0.20 0.045 22 / 0.55), transparent 60%),
+      radial-gradient(ellipse 70% 55% at 10% 100%,  oklch(0.22 0.040 355 / 0.45), transparent 60%),
+      linear-gradient(135deg, oklch(0.13 0.010 30) 0%, oklch(0.12 0.015 22) 55%, oklch(0.13 0.018 355) 100%);
     background-attachment: fixed;
   }
 }

--- a/projects/web/src/lib/ring-geometry.ts
+++ b/projects/web/src/lib/ring-geometry.ts
@@ -13,9 +13,9 @@ export const RING = {
 export const RING_SWEEP = RING.END_ANGLE - RING.START_ANGLE; // 240°
 
 export const RING_COLORS = {
-  track:     'oklch(0.928 0.006 264)',
-  work:      '#E5173F',
-  over:      '#F97316',
+  track:     'var(--ring-track)',
+  work:      'hsl(var(--primary))',
+  over:      'hsl(var(--ring-over))',
   break:     'oklch(0.78 0.115 22)',
   breakHint: 'oklch(0.90 0.060 22)',
 } as const;

--- a/projects/web/src/main.tsx
+++ b/projects/web/src/main.tsx
@@ -2,14 +2,17 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './hooks/ThemeProvider.tsx'
 import { ToastProvider } from './hooks/ToastProvider.tsx'
 import { Toaster } from './components/ui/toaster.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ToastProvider>
-      <App />
-      <Toaster />
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <App />
+        <Toaster />
+      </ToastProvider>
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
- ThemeProvider (system/light/dark) mit localStorage-Persistenz und live
  matchMedia('prefers-color-scheme')-Sync, Default „system"
- No-FOUC-Inline-Script in index.html setzt .dark vor erstem Paint
- Theme-Submenu „Erscheinungsbild" im ProfileMenu (Sun/Moon/MonitorSmartphone)
- Body-Hintergrund-Variante für .dark im index.css
- Neue Tokens --ring-over und --ring-track für die Timer-Ring-Farben
- Hartcodierte Farben (#E5173F, #cc1538, #F97316, #999, rgba/white) durch
  semantische Tokens (bg-primary, text-muted-foreground, bg-card, …) ersetzt
  in App, submit-button, text-field, app-bar-shell, surface-classes,
  bottom-bar-action, BreaksTrigger, BreakTooltip, TimerRing, ring-geometry, logo
- BrandPanel bleibt unverändert (markiertes Brand-Hero auf Login)
- Light Mode visuell unverändert, alle Tokens entsprechen den Vor-Werten

https://claude.ai/code/session_01NWHYiEtCVwueMPPcLsvnBP