### PR TITLE
fix: show all workday messages as consistent styled pills

### DIFF
--- a/projects/web/src/components/features/timer/SaldoCenter.tsx
+++ b/projects/web/src/components/features/timer/SaldoCenter.tsx
@@ -32,31 +32,37 @@ export function SaldoCenter({ saldoText, isOvertime, message }: SaldoCenterProps
   const Icon = message ? SEVERITY_ICON[message.severity] : null;
 
   return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center text-center select-none pointer-events-none px-8">
-      <Eyebrow size="xs" className="text-muted-foreground/50 mb-2.5">
-        {isOvertime ? 'Überstunden' : 'Saldo'}
-      </Eyebrow>
-      <div
-        className={cn(
-          'font-bold tabular-nums leading-none tracking-tight',
-          'text-[50px] sm:text-[62px]',
-        )}
-        style={{ color: RING_COLORS.work }}
-      >
-        {saldoText}
-      </div>
-      {message && Icon && (
+    <div className="absolute inset-0 select-none pointer-events-none">
+      {/* Saldo pinned to ring center, independent of message */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-8">
+        <Eyebrow size="xs" className="text-muted-foreground/50 mb-2.5">
+          {isOvertime ? 'Überstunden' : 'Saldo'}
+        </Eyebrow>
         <div
-          role={message.severity === 'urgent' ? 'alert' : 'status'}
           className={cn(
-            'mt-3 max-w-[80%] flex items-center justify-center gap-1.5',
-            'text-[12px] sm:text-[13px] font-medium leading-snug',
-            'px-2.5 py-1 rounded-full',
-            SEVERITY_CLASS[message.severity],
+            'font-bold tabular-nums leading-none tracking-tight',
+            'text-[50px] sm:text-[62px]',
           )}
+          style={{ color: RING_COLORS.work }}
         >
-          <Icon className="h-3.5 w-3.5 shrink-0 mt-px" />
-          <span className="text-balance">{message.text}</span>
+          {saldoText}
+        </div>
+      </div>
+      {/* Message in ring's bottom opening (below arc end-caps at ~y=245 SVG) */}
+      {message && Icon && (
+        <div className="absolute bottom-[8%] left-0 right-0 flex items-center justify-center px-6">
+          <div
+            role={message.severity === 'urgent' ? 'alert' : 'status'}
+            className={cn(
+              'max-w-[75%] flex items-center justify-center gap-1.5',
+              'text-[12px] sm:text-[13px] font-medium leading-snug',
+              'px-2.5 py-1 rounded-full',
+              SEVERITY_CLASS[message.severity],
+            )}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            <span className="text-balance">{message.text}</span>
+          </div>
         </div>
       )}
     </div>

--- a/projects/web/src/components/features/timer/SaldoCenter.tsx
+++ b/projects/web/src/components/features/timer/SaldoCenter.tsx
@@ -32,37 +32,31 @@ export function SaldoCenter({ saldoText, isOvertime, message }: SaldoCenterProps
   const Icon = message ? SEVERITY_ICON[message.severity] : null;
 
   return (
-    <div className="absolute inset-0 select-none pointer-events-none">
-      {/* Saldo pinned to ring center, independent of message */}
-      <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-8">
-        <Eyebrow size="xs" className="text-muted-foreground/50 mb-2.5">
-          {isOvertime ? 'Überstunden' : 'Saldo'}
-        </Eyebrow>
-        <div
-          className={cn(
-            'font-bold tabular-nums leading-none tracking-tight',
-            'text-[50px] sm:text-[62px]',
-          )}
-          style={{ color: RING_COLORS.work }}
-        >
-          {saldoText}
-        </div>
+    <div className="absolute inset-0 flex flex-col items-center justify-center text-center select-none pointer-events-none px-8">
+      <Eyebrow size="xs" className="text-muted-foreground/50 mb-2.5">
+        {isOvertime ? 'Überstunden' : 'Saldo'}
+      </Eyebrow>
+      <div
+        className={cn(
+          'font-bold tabular-nums leading-none tracking-tight',
+          'text-[50px] sm:text-[62px]',
+        )}
+        style={{ color: RING_COLORS.work }}
+      >
+        {saldoText}
       </div>
-      {/* Message in ring's bottom opening (below arc end-caps at ~y=245 SVG) */}
       {message && Icon && (
-        <div className="absolute bottom-[8%] left-0 right-0 flex items-center justify-center px-6">
-          <div
-            role={message.severity === 'urgent' ? 'alert' : 'status'}
-            className={cn(
-              'max-w-[75%] flex items-center justify-center gap-1.5',
-              'text-[12px] sm:text-[13px] font-medium leading-snug',
-              'px-2.5 py-1 rounded-full',
-              SEVERITY_CLASS[message.severity],
-            )}
-          >
-            <Icon className="h-3.5 w-3.5 shrink-0" />
-            <span className="text-balance">{message.text}</span>
-          </div>
+        <div
+          role={message.severity === 'urgent' ? 'alert' : 'status'}
+          className={cn(
+            'mt-3 max-w-[65%] flex items-center justify-center gap-1.5',
+            'text-[12px] sm:text-[13px] font-medium leading-snug',
+            'px-2.5 py-1 rounded-full',
+            SEVERITY_CLASS[message.severity],
+          )}
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0" />
+          <span className="text-balance">{message.text}</span>
         </div>
       )}
     </div>

--- a/projects/web/src/components/features/timer/SaldoCenter.tsx
+++ b/projects/web/src/components/features/timer/SaldoCenter.tsx
@@ -21,8 +21,8 @@ const SEVERITY_ICON: Record<WorkdayMessageSeverity, ComponentType<{ className?: 
 const SEVERITY_CLASS: Record<WorkdayMessageSeverity, string> = {
   urgent:  'bg-destructive/12 text-destructive animate-pulse',
   warning: 'bg-orange-500/12 text-orange-700 dark:text-orange-300',
-  success: 'text-green-600 dark:text-green-500',
-  info:    'text-muted-foreground/90',
+  success: 'bg-green-500/12 text-green-600 dark:text-green-500',
+  info:    'bg-muted/60 text-muted-foreground/90',
 };
 
 /**
@@ -30,7 +30,6 @@ const SEVERITY_CLASS: Record<WorkdayMessageSeverity, string> = {
  */
 export function SaldoCenter({ saldoText, isOvertime, message }: SaldoCenterProps) {
   const Icon = message ? SEVERITY_ICON[message.severity] : null;
-  const isProminent = message?.severity === 'urgent' || message?.severity === 'warning';
 
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center text-center select-none pointer-events-none px-8">
@@ -50,9 +49,9 @@ export function SaldoCenter({ saldoText, isOvertime, message }: SaldoCenterProps
         <div
           role={message.severity === 'urgent' ? 'alert' : 'status'}
           className={cn(
-            'mt-3 max-w-[80%] flex items-start justify-center gap-1.5',
+            'mt-3 max-w-[80%] flex items-center justify-center gap-1.5',
             'text-[12px] sm:text-[13px] font-medium leading-snug',
-            isProminent && 'px-2.5 py-1 rounded-full',
+            'px-2.5 py-1 rounded-full',
             SEVERITY_CLASS[message.severity],
           )}
         >

--- a/projects/web/src/components/features/timer/workdayStatus.ts
+++ b/projects/web/src/components/features/timer/workdayStatus.ts
@@ -64,14 +64,14 @@ export function getWorkdayMessage({
 
   if (minutesToTen < 0) {
     return {
-      text: `10h-Grenze seit ${Math.floor(-minutesToTen)} Min. überschritten – du solltest jetzt Feierabend machen`,
+      text: `10h-Grenze seit ${Math.floor(-minutesToTen)} Min. überschritten!`,
       severity: 'urgent',
     };
   }
 
   if (minutesToTen <= WORKDAY_TEN_HOUR_URGENT_MINUTES) {
     return {
-      text: `Noch ${Math.floor(minutesToTen)} Minuten bis zur gesetzlichen 10h-Grenze`,
+      text: `Noch ${Math.floor(minutesToTen)} Min. bis zur gesetzlichen 10h-Grenze`,
       severity: 'urgent',
     };
   }
@@ -79,28 +79,28 @@ export function getWorkdayMessage({
   if (minutesToTen <= WORKDAY_TEN_HOUR_WARN_MINUTES) {
     const tenAtMin = nowMin + minutesToTen;
     return {
-      text: `Noch ${Math.floor(minutesToTen)} Minuten bis zur 10h-Grenze (um ${formatHHMM(tenAtMin)})`,
+      text: `Noch ${Math.floor(minutesToTen)} Min. bis zur 10h-Grenze (um ${formatHHMM(tenAtMin)})`,
       severity: 'warning',
     };
   }
 
   if (legalPauseRunning) {
     return {
-      text: `Gesetzliche Pause wird gerade abgezogen (noch ${legalPauseMinsRemaining} Min.)`,
+      text: `Pausenabzug läuft – noch ${legalPauseMinsRemaining} Min.`,
       severity: 'urgent',
     };
   }
 
   if (nextLegalPauseIn !== null && nextLegalPauseIn <= WORKDAY_PAUSE_URGENT_MINUTES) {
     return {
-      text: `In ${Math.ceil(nextLegalPauseIn)} Minuten erfolgt ein Pausenabzug – jetzt Feierabend spart dir ${nextLegalPauseDeduction} Minuten`,
+      text: `In ${Math.ceil(nextLegalPauseIn)} Min. Abzug – Feierabend spart ${nextLegalPauseDeduction} Min.`,
       severity: 'warning',
     };
   }
 
   if (nextLegalPauseIn !== null && nextLegalPauseIn <= WORKDAY_PAUSE_WARN_MINUTES) {
     return {
-      text: `In ${Math.ceil(nextLegalPauseIn)} Minuten wird ein gesetzlicher Pausenabzug fällig`,
+      text: `In ${Math.ceil(nextLegalPauseIn)} Min. wird ein Pausenabzug fällig`,
       severity: 'warning',
     };
   }
@@ -144,7 +144,7 @@ export function getWorkdayMessage({
 
   if (overtimeMin > 0) {
     return {
-      text: `Du machst Überstunden – +${Math.floor(overtimeMin)} Minuten über Soll`,
+      text: `Du machst +${Math.floor(overtimeMin)} Min. Überstunden`,
       severity: 'info',
     };
   }


### PR DESCRIPTION
info and success severity messages were rendering as bare floating text
without any background container, looking broken compared to warning/urgent
pills. All four severity levels now get pill styling with appropriate
background colors.

https://claude.ai/code/session_01WkxVcWgfKGwmP8Y9vrxJMD