### PR TITLE
feat: offene Pausen (live break) – Pause ohne bekanntes Ende starten

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fi-go",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fi-go",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "workspaces": [
         "projects/*"
       ],
@@ -29306,7 +29306,7 @@
         "firebase": "^12.12.1",
         "globals": "^17.5.0",
         "lucide-react": "^1.11.0",
-        "postcss": "8.5.12",
+        "postcss": "^8.5.12",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwind-merge": "^3.5.0",

--- a/projects/functions/src/index.ts
+++ b/projects/functions/src/index.ts
@@ -66,6 +66,13 @@ export const onSessionDataWritten = onValueWritten({
   }
 
   const startTimeMillis = data.startTime;
+
+  // Live break is running — do not schedule notifications until it ends
+  if (typeof data.liveBreakStart === 'number') {
+    logger.info(`Live break running for ${userId}. Skipping push schedule.`);
+    return;
+  }
+
   const breaks          = parseBreaksFromRtdb(data.breaks);
   const manualBreaksMinutes = calculateManualBreaksMinutes(breaks);
   const projectedBreakMinutesTarget = calculateAppliedBreakMinutes(WORK_TIME_TARGET_MINUTES, manualBreaksMinutes);

--- a/projects/functions/src/index.ts
+++ b/projects/functions/src/index.ts
@@ -121,6 +121,12 @@ export const onSendPushNotification = onTaskDispatched<PushPayload>(
       return;
     }
 
+    // A live break started after this task was queued — skip the notification
+    if (typeof data.liveBreakStart === 'number') {
+      logger.info(`Task aborted: Live break running for ${payload.userId}.`);
+      return;
+    }
+
     const breaks = parseBreaksFromRtdb(data.breaks);
     const currentManualBreaksMinutes = calculateManualBreaksMinutes(breaks);
     if (currentManualBreaksMinutes !== payload.breaksDurationMinutes) {

--- a/projects/shared/src/breaks.ts
+++ b/projects/shared/src/breaks.ts
@@ -47,10 +47,17 @@ export function calculateLegalMinimumBreakMinutes(grossWorkMinutes: number): num
   return BREAK_RULE_2_REQUIRED_MINUTES; // 45 mins
 }
 
-// Total minutes from a list of manually recorded breaks
-export function calculateManualBreaksMinutes(breaks: BreakRecord[]): number {
-  const millis = breaks.reduce((acc, brk) => acc + Math.max(0, differenceInMilliseconds(brk.end, brk.start)), 0);
-  return Math.floor(millis / 60000);
+// Total minutes from a list of manually recorded breaks, plus an optional live (open) break.
+export function calculateManualBreaksMinutes(
+  breaks: BreakRecord[],
+  liveBreakStart?: Date | null,
+  now?: Date,
+): number {
+  const completedMillis = breaks.reduce((acc, brk) => acc + Math.max(0, differenceInMilliseconds(brk.end, brk.start)), 0);
+  const liveMillis = liveBreakStart
+    ? Math.max(0, differenceInMilliseconds(now ?? new Date(), liveBreakStart))
+    : 0;
+  return Math.floor((completedMillis + liveMillis) / 60000);
 }
 
 /**

--- a/projects/shared/src/workTime.ts
+++ b/projects/shared/src/workTime.ts
@@ -20,3 +20,8 @@ export function calculateNetWorkTimeMinutes(grossWorkMinutes: number, appliedBre
 export function calculateSaldoMinutes(netWorkMinutes: number): number {
   return netWorkMinutes - WORK_TIME_TARGET_MINUTES;
 }
+
+// Elapsed minutes between two timestamps (non-negative)
+export function calculateElapsedMinutes(since: Date, until: Date = new Date()): number {
+  return Math.max(0, Math.floor(differenceInMilliseconds(until, since) / 60000));
+}

--- a/projects/web/src/App.tsx
+++ b/projects/web/src/App.tsx
@@ -20,12 +20,15 @@ export default function App() {
     startTime,
     breaks,
     dailyMaxOvertimeMinutes,
+    liveBreakStart,
     loading: sessionLoading,
     clockIn,
     clockOut,
     addBreak,
     removeBreak,
     setDailyMaxOvertime,
+    startLiveBreak,
+    endLiveBreak,
   } = useSessionData();
 
   const [isDailyMaxOpen, setIsDailyMaxOpen] = useState(false);
@@ -52,9 +55,19 @@ export default function App() {
     );
   }
 
+  const breaksDrawerProps = {
+    breaks,
+    onAddBreak: addBreak,
+    onRemoveBreak: removeBreak,
+    startTime,
+    liveBreakStart,
+    onStartLiveBreak: startLiveBreak,
+    onEndLiveBreak: endLiveBreak,
+  };
+
   const bottomBar = (
     <Surface variant="bar" className="flex justify-around items-center w-full py-3 px-4">
-      <BreaksDrawer breaks={breaks} onAddBreak={addBreak} onRemoveBreak={removeBreak} startTime={startTime} />
+      <BreaksDrawer {...breaksDrawerProps} />
       <BottomBarAction
         icon={<LogOut className="h-6 w-6" />}
         label="Feierabend"
@@ -65,7 +78,7 @@ export default function App() {
 
   const desktopActions = (
     <>
-      <BreaksDrawer breaks={breaks} onAddBreak={addBreak} onRemoveBreak={removeBreak} startTime={startTime} desktopMode />
+      <BreaksDrawer {...breaksDrawerProps} desktopMode />
       <Button
         onClick={clockOut}
         className="rounded-full bg-primary text-white hover:brightness-110 shadow-[0_0_14px_hsl(var(--primary)/0.38)] border-0"
@@ -97,7 +110,7 @@ export default function App() {
       dailyMaxActive={dailyMaxOvertimeMinutes !== null}
       dailyMaxDialog={dailyMaxDialog}
     >
-      <DisplayScreen startTime={startTime} breaks={breaks} maxOvertimeMinutes={dailyMaxOvertimeMinutes} />
+      <DisplayScreen startTime={startTime} breaks={breaks} maxOvertimeMinutes={dailyMaxOvertimeMinutes} liveBreakStart={liveBreakStart} />
     </AppLayout>
   );
 }

--- a/projects/web/src/components/features/breaks/BreaksAddForm.tsx
+++ b/projects/web/src/components/features/breaks/BreaksAddForm.tsx
@@ -12,10 +12,9 @@ interface BreaksAddFormProps {
   startTime: Date;
   breaks: FirebaseBreakRecord[];
   onAdd: (start: Date, end: Date) => Promise<void>;
-  liveBreakRunning?: boolean;
 }
 
-export function BreaksAddForm({ startTime, breaks, onAdd, liveBreakRunning }: BreaksAddFormProps) {
+export function BreaksAddForm({ startTime, breaks, onAdd }: BreaksAddFormProps) {
   const [startStr, setStartStr] = useState('');
   const [endStr, setEndStr] = useState('');
   const [loading, setLoading] = useState(false);
@@ -50,51 +49,45 @@ export function BreaksAddForm({ startTime, breaks, onAdd, liveBreakRunning }: Br
     <section className="space-y-3">
       <Eyebrow as="h3">Neue Pause erfassen</Eyebrow>
 
-      {liveBreakRunning ? (
-        <div className="rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700 text-center dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-400">
-          Beende zuerst die laufende Pause.
-        </div>
-      ) : (
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            {/* min-w-0 prevents grid children from overflowing on iOS */}
-            <div className="space-y-1.5 min-w-0">
-              <label className="text-xs font-medium pl-1">Start</label>
-              <Input
-                type="time"
-                value={startStr}
-                onChange={e => setStartStr(e.target.value)}
-                required
-                className="h-12 text-lg text-center font-mono px-1"
-              />
-            </div>
-            <div className="space-y-1.5 min-w-0">
-              <label className="text-xs font-medium pl-1">Ende</label>
-              <Input
-                type="time"
-                value={endStr}
-                onChange={e => setEndStr(e.target.value)}
-                required
-                className="h-12 text-lg text-center font-mono px-1"
-              />
-            </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          {/* min-w-0 prevents grid children from overflowing on iOS */}
+          <div className="space-y-1.5 min-w-0">
+            <label className="text-xs font-medium pl-1">Start</label>
+            <Input
+              type="time"
+              value={startStr}
+              onChange={e => setStartStr(e.target.value)}
+              required
+              className="h-12 text-lg text-center font-mono px-1"
+            />
           </div>
+          <div className="space-y-1.5 min-w-0">
+            <label className="text-xs font-medium pl-1">Ende</label>
+            <Input
+              type="time"
+              value={endStr}
+              onChange={e => setEndStr(e.target.value)}
+              required
+              className="h-12 text-lg text-center font-mono px-1"
+            />
+          </div>
+        </div>
 
-          {isOrderInvalid && <FormError>Die Endzeit muss nach der Startzeit liegen.</FormError>}
-          {isBeforeStart  && <FormError>Pause kann nicht vor Dienstbeginn ({format(startTime, 'HH:mm')}) liegen.</FormError>}
-          {hasOverlap     && <FormError>Diese Pause überschneidet sich mit einer bestehenden Pause.</FormError>}
+        {isOrderInvalid && <FormError>Die Endzeit muss nach der Startzeit liegen.</FormError>}
+        {isBeforeStart  && <FormError>Pause kann nicht vor Dienstbeginn ({format(startTime, 'HH:mm')}) liegen.</FormError>}
+        {hasOverlap     && <FormError>Diese Pause überschneidet sich mit einer bestehenden Pause.</FormError>}
 
-          <SubmitButton
-            type="submit"
-            disabled={isInvalid}
-            loading={loading}
-            className="h-12"
-          >
-            <Plus className="h-5 w-5" />
-            Pause hinzufügen
-          </SubmitButton>
-        </form>
-      )}
+        <SubmitButton
+          type="submit"
+          disabled={isInvalid}
+          loading={loading}
+          className="h-12"
+        >
+          <Plus className="h-5 w-5" />
+          Pause hinzufügen
+        </SubmitButton>
+      </form>
     </section>
   );
 }

--- a/projects/web/src/components/features/breaks/BreaksAddForm.tsx
+++ b/projects/web/src/components/features/breaks/BreaksAddForm.tsx
@@ -16,16 +16,6 @@ interface BreaksAddFormProps {
 }
 
 export function BreaksAddForm({ startTime, breaks, onAdd, liveBreakRunning }: BreaksAddFormProps) {
-  if (liveBreakRunning) {
-    return (
-      <section className="space-y-3">
-        <Eyebrow as="h3">Neue Pause erfassen</Eyebrow>
-        <div className="rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700 text-center dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-400">
-          Beende zuerst die laufende Pause.
-        </div>
-      </section>
-    );
-  }
   const [startStr, setStartStr] = useState('');
   const [endStr, setEndStr] = useState('');
   const [loading, setLoading] = useState(false);
@@ -60,45 +50,51 @@ export function BreaksAddForm({ startTime, breaks, onAdd, liveBreakRunning }: Br
     <section className="space-y-3">
       <Eyebrow as="h3">Neue Pause erfassen</Eyebrow>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          {/* min-w-0 prevents grid children from overflowing on iOS */}
-          <div className="space-y-1.5 min-w-0">
-            <label className="text-xs font-medium pl-1">Start</label>
-            <Input
-              type="time"
-              value={startStr}
-              onChange={e => setStartStr(e.target.value)}
-              required
-              className="h-12 text-lg text-center font-mono px-1"
-            />
-          </div>
-          <div className="space-y-1.5 min-w-0">
-            <label className="text-xs font-medium pl-1">Ende</label>
-            <Input
-              type="time"
-              value={endStr}
-              onChange={e => setEndStr(e.target.value)}
-              required
-              className="h-12 text-lg text-center font-mono px-1"
-            />
-          </div>
+      {liveBreakRunning ? (
+        <div className="rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700 text-center dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-400">
+          Beende zuerst die laufende Pause.
         </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            {/* min-w-0 prevents grid children from overflowing on iOS */}
+            <div className="space-y-1.5 min-w-0">
+              <label className="text-xs font-medium pl-1">Start</label>
+              <Input
+                type="time"
+                value={startStr}
+                onChange={e => setStartStr(e.target.value)}
+                required
+                className="h-12 text-lg text-center font-mono px-1"
+              />
+            </div>
+            <div className="space-y-1.5 min-w-0">
+              <label className="text-xs font-medium pl-1">Ende</label>
+              <Input
+                type="time"
+                value={endStr}
+                onChange={e => setEndStr(e.target.value)}
+                required
+                className="h-12 text-lg text-center font-mono px-1"
+              />
+            </div>
+          </div>
 
-        {isOrderInvalid && <FormError>Die Endzeit muss nach der Startzeit liegen.</FormError>}
-        {isBeforeStart  && <FormError>Pause kann nicht vor Dienstbeginn ({format(startTime, 'HH:mm')}) liegen.</FormError>}
-        {hasOverlap     && <FormError>Diese Pause überschneidet sich mit einer bestehenden Pause.</FormError>}
+          {isOrderInvalid && <FormError>Die Endzeit muss nach der Startzeit liegen.</FormError>}
+          {isBeforeStart  && <FormError>Pause kann nicht vor Dienstbeginn ({format(startTime, 'HH:mm')}) liegen.</FormError>}
+          {hasOverlap     && <FormError>Diese Pause überschneidet sich mit einer bestehenden Pause.</FormError>}
 
-        <SubmitButton
-          type="submit"
-          disabled={isInvalid}
-          loading={loading}
-          className="h-12"
-        >
-          <Plus className="h-5 w-5" />
-          Pause hinzufügen
-        </SubmitButton>
-      </form>
+          <SubmitButton
+            type="submit"
+            disabled={isInvalid}
+            loading={loading}
+            className="h-12"
+          >
+            <Plus className="h-5 w-5" />
+            Pause hinzufügen
+          </SubmitButton>
+        </form>
+      )}
     </section>
   );
 }

--- a/projects/web/src/components/features/breaks/BreaksAddForm.tsx
+++ b/projects/web/src/components/features/breaks/BreaksAddForm.tsx
@@ -12,9 +12,20 @@ interface BreaksAddFormProps {
   startTime: Date;
   breaks: FirebaseBreakRecord[];
   onAdd: (start: Date, end: Date) => Promise<void>;
+  liveBreakRunning?: boolean;
 }
 
-export function BreaksAddForm({ startTime, breaks, onAdd }: BreaksAddFormProps) {
+export function BreaksAddForm({ startTime, breaks, onAdd, liveBreakRunning }: BreaksAddFormProps) {
+  if (liveBreakRunning) {
+    return (
+      <section className="space-y-3">
+        <Eyebrow as="h3">Neue Pause erfassen</Eyebrow>
+        <div className="rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700 text-center dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-400">
+          Beende zuerst die laufende Pause.
+        </div>
+      </section>
+    );
+  }
   const [startStr, setStartStr] = useState('');
   const [endStr, setEndStr] = useState('');
   const [loading, setLoading] = useState(false);

--- a/projects/web/src/components/features/breaks/BreaksDrawer.tsx
+++ b/projects/web/src/components/features/breaks/BreaksDrawer.tsx
@@ -28,10 +28,16 @@ interface BreaksDrawerProps {
 
 export function BreaksDrawer({ breaks, onAddBreak, onRemoveBreak, startTime, liveBreakStart, onStartLiveBreak, onEndLiveBreak, desktopMode }: BreaksDrawerProps) {
   const [open, setOpen] = useState(false);
+  const [showManualAdd, setShowManualAdd] = useState(false);
   const focusRef = useRef<HTMLDivElement>(null);
 
+  function handleOpenChange(v: boolean) {
+    setOpen(v);
+    if (!v) setShowManualAdd(false);
+  }
+
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
+    <Drawer open={open} onOpenChange={handleOpenChange}>
       <DrawerTrigger asChild>
         <BreaksTrigger desktopMode={desktopMode} liveBreakRunning={liveBreakStart !== null} />
       </DrawerTrigger>
@@ -68,8 +74,20 @@ export function BreaksDrawer({ breaks, onAddBreak, onRemoveBreak, startTime, liv
               onStart={onStartLiveBreak}
             />
           )}
-          <BreaksList breaks={breaks} onRemove={onRemoveBreak} />
-          <BreaksAddForm startTime={startTime} breaks={breaks} onAdd={onAddBreak} liveBreakRunning={liveBreakStart !== null} />
+          <BreaksList
+            breaks={breaks}
+            onRemove={onRemoveBreak}
+            showAddButton={!liveBreakStart}
+            addOpen={showManualAdd}
+            onAddToggle={() => setShowManualAdd(v => !v)}
+          />
+          {showManualAdd && !liveBreakStart && (
+            <BreaksAddForm
+              startTime={startTime}
+              breaks={breaks}
+              onAdd={async (s, e) => { await onAddBreak(s, e); setShowManualAdd(false); }}
+            />
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/projects/web/src/components/features/breaks/BreaksDrawer.tsx
+++ b/projects/web/src/components/features/breaks/BreaksDrawer.tsx
@@ -11,6 +11,8 @@ import { Coffee } from 'lucide-react';
 import { BreaksTrigger } from './BreaksTrigger';
 import { BreaksList } from './BreaksList';
 import { BreaksAddForm } from './BreaksAddForm';
+import { StartBreakForm } from './StartBreakForm';
+import { LiveBreakPanel } from './LiveBreakPanel';
 import type { FirebaseBreakRecord } from '@/hooks/useSessionData';
 
 interface BreaksDrawerProps {
@@ -18,17 +20,20 @@ interface BreaksDrawerProps {
   onAddBreak: (start: Date, end: Date) => Promise<void>;
   onRemoveBreak: (id: string) => void;
   startTime: Date;
+  liveBreakStart: Date | null;
+  onStartLiveBreak: (startTime: Date) => Promise<void>;
+  onEndLiveBreak: (endTime: Date) => Promise<void>;
   desktopMode?: boolean;
 }
 
-export function BreaksDrawer({ breaks, onAddBreak, onRemoveBreak, startTime, desktopMode }: BreaksDrawerProps) {
+export function BreaksDrawer({ breaks, onAddBreak, onRemoveBreak, startTime, liveBreakStart, onStartLiveBreak, onEndLiveBreak, desktopMode }: BreaksDrawerProps) {
   const [open, setOpen] = useState(false);
   const focusRef = useRef<HTMLDivElement>(null);
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerTrigger asChild>
-        <BreaksTrigger desktopMode={desktopMode} />
+        <BreaksTrigger desktopMode={desktopMode} liveBreakRunning={liveBreakStart !== null} />
       </DrawerTrigger>
 
       <DrawerContent
@@ -42,17 +47,29 @@ export function BreaksDrawer({ breaks, onAddBreak, onRemoveBreak, startTime, des
       >
         <DrawerHeader className="pb-3">
           <DrawerTitle className="text-2xl text-center flex items-center justify-center gap-2">
-            <Coffee className="h-6 w-6 text-primary" /> Manuelle Pausen
+            <Coffee className="h-6 w-6 text-primary" /> Pausen
           </DrawerTitle>
           <DrawerDescription className="text-center">
-            Pausenzeiten manuell erfassen oder löschen.
+            Pausenzeiten erfassen oder löschen.
           </DrawerDescription>
         </DrawerHeader>
 
         {/* tabIndex={-1}/outline-none: programmatic focus target, not in tab order */}
         <div ref={focusRef} tabIndex={-1} className="flex-1 min-h-0 overflow-y-auto px-4 pb-8 flex flex-col gap-6 outline-none">
+          {liveBreakStart ? (
+            <LiveBreakPanel
+              liveBreakStart={liveBreakStart}
+              workdayStartTime={startTime}
+              onEnd={onEndLiveBreak}
+            />
+          ) : (
+            <StartBreakForm
+              workdayStartTime={startTime}
+              onStart={onStartLiveBreak}
+            />
+          )}
           <BreaksList breaks={breaks} onRemove={onRemoveBreak} />
-          <BreaksAddForm startTime={startTime} breaks={breaks} onAdd={onAddBreak} />
+          <BreaksAddForm startTime={startTime} breaks={breaks} onAdd={onAddBreak} liveBreakRunning={liveBreakStart !== null} />
         </div>
       </DrawerContent>
     </Drawer>

--- a/projects/web/src/components/features/breaks/BreaksList.tsx
+++ b/projects/web/src/components/features/breaks/BreaksList.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { Clock, Trash2 } from 'lucide-react';
+import { Clock, Plus, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import type { FirebaseBreakRecord } from '@/hooks/useSessionData';
@@ -7,9 +7,12 @@ import type { FirebaseBreakRecord } from '@/hooks/useSessionData';
 interface BreaksListProps {
   breaks: FirebaseBreakRecord[];
   onRemove: (id: string) => void;
+  showAddButton?: boolean;
+  addOpen?: boolean;
+  onAddToggle?: () => void;
 }
 
-export function BreaksList({ breaks, onRemove }: BreaksListProps) {
+export function BreaksList({ breaks, onRemove, showAddButton, addOpen, onAddToggle }: BreaksListProps) {
   const totalMins = breaks.reduce(
     (sum, b) => sum + Math.floor((b.end.getTime() - b.start.getTime()) / 60000),
     0,
@@ -19,11 +22,24 @@ export function BreaksList({ breaks, onRemove }: BreaksListProps) {
     <section className="space-y-2">
       <div className="flex items-center justify-between">
         <Eyebrow as="h3">Erfasste Pausen</Eyebrow>
-        {breaks.length > 0 && (
-          <span className="text-[11px] text-muted-foreground/70 tabular-nums">
-            {totalMins} Min. gesamt
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {breaks.length > 0 && (
+            <span className="text-[11px] text-muted-foreground/70 tabular-nums">
+              {totalMins} Min. gesamt
+            </span>
+          )}
+          {showAddButton && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onAddToggle}
+              className="h-7 w-7 text-muted-foreground hover:text-foreground -mr-1"
+              aria-label={addOpen ? 'Formular schließen' : 'Pause manuell erfassen'}
+            >
+              {addOpen ? <X className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+            </Button>
+          )}
+        </div>
       </div>
 
       {breaks.length === 0 ? (

--- a/projects/web/src/components/features/breaks/BreaksTrigger.tsx
+++ b/projects/web/src/components/features/breaks/BreaksTrigger.tsx
@@ -6,26 +6,43 @@ import { BottomBarAction } from '@/components/ui/bottom-bar-action';
 interface BreaksTriggerProps {
   /** Desktop-Variante: Pill-Button mit Icon + Label. Mobile: vertikal im BottomBar. */
   desktopMode?: boolean;
+  /** Zeigt einen Puls-Indikator wenn eine offene Pause läuft. */
+  liveBreakRunning?: boolean;
 }
 
 export const BreaksTrigger = forwardRef<HTMLButtonElement, BreaksTriggerProps>(
-  function BreaksTrigger({ desktopMode, ...props }, ref) {
+  function BreaksTrigger({ desktopMode, liveBreakRunning, ...props }, ref) {
+    const icon = (
+      <span className="relative inline-flex">
+        <Coffee className={desktopMode ? 'mr-2 h-4 w-4' : 'h-6 w-6'} />
+        {liveBreakRunning && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-orange-500" />
+          </span>
+        )}
+      </span>
+    );
+
     if (desktopMode) {
       return (
         <Button
           ref={ref}
           variant="ghost"
-          className="rounded-full border border-primary text-primary hover:bg-primary/10 hover:text-primary"
+          className={liveBreakRunning
+            ? 'rounded-full border border-orange-400 text-orange-500 hover:bg-orange-500/10 hover:text-orange-500'
+            : 'rounded-full border border-primary text-primary hover:bg-primary/10 hover:text-primary'
+          }
           {...props}
         >
-          <Coffee className="mr-2 h-4 w-4" /> Pausen
+          {icon} Pausen
         </Button>
       );
     }
     return (
       <BottomBarAction
         ref={ref}
-        icon={<Coffee className="h-6 w-6" />}
+        icon={icon}
         label="Pausen"
         {...props}
       />

--- a/projects/web/src/components/features/breaks/LiveBreakPanel.tsx
+++ b/projects/web/src/components/features/breaks/LiveBreakPanel.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect, type FormEvent } from 'react';
+import { format } from 'date-fns';
+import { Square } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { FormError } from '@/components/ui/form-error';
+import { SubmitButton } from '@/components/ui/submit-button';
+import { parseToTodayDate } from '@/lib/time';
+
+interface LiveBreakPanelProps {
+  liveBreakStart: Date;
+  workdayStartTime: Date;
+  onEnd: (endTime: Date) => Promise<void>;
+}
+
+function useElapsedMinutes(since: Date): number {
+  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - since.getTime()) / 60000));
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(Math.floor((Date.now() - since.getTime()) / 60000)), 1000);
+    return () => clearInterval(id);
+  }, [since]);
+  return elapsed;
+}
+
+export function LiveBreakPanel({ liveBreakStart, workdayStartTime, onEnd }: LiveBreakPanelProps) {
+  const [endStr, setEndStr] = useState(format(new Date(), 'HH:mm'));
+  const [loading, setLoading] = useState(false);
+  const elapsedMin = useElapsedMinutes(liveBreakStart);
+
+  const parsedEnd = endStr ? parseToTodayDate(endStr) : null;
+  const isBeforeStart = !!(parsedEnd && parsedEnd <= liveBreakStart);
+  const isBeforeWorkday = !!(parsedEnd && parsedEnd < workdayStartTime);
+  const isInFuture = !!(parsedEnd && parsedEnd > new Date());
+  const isInvalid = !endStr || isBeforeStart || isBeforeWorkday || isInFuture;
+
+  const h = Math.floor(elapsedMin / 60);
+  const m = elapsedMin % 60;
+  const durationText = h > 0
+    ? `${h}:${String(m).padStart(2, '0')} Std.`
+    : `${m} Min.`;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isInvalid || loading || !parsedEnd) return;
+
+    setLoading(true);
+    try {
+      await onEnd(parsedEnd);
+    } catch (error) {
+      console.error('End live break error:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <Eyebrow as="h3">Pause läuft</Eyebrow>
+
+      <div className="rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 dark:border-orange-800 dark:bg-orange-950/30">
+        <div className="flex items-center gap-2 text-orange-700 dark:text-orange-400">
+          <span className="relative flex h-2.5 w-2.5 shrink-0">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-orange-500" />
+          </span>
+          <span className="text-sm font-medium">
+            Seit {format(liveBreakStart, 'HH:mm')} – {durationText}
+          </span>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium pl-1">Beendet um</label>
+          <Input
+            type="time"
+            value={endStr}
+            onChange={e => setEndStr(e.target.value)}
+            required
+            className="h-12 text-lg text-center font-mono px-1"
+          />
+        </div>
+
+        {isBeforeStart && <FormError>Endzeit muss nach {format(liveBreakStart, 'HH:mm')} liegen.</FormError>}
+        {isBeforeWorkday && <FormError>Endzeit darf nicht vor Dienstbeginn liegen.</FormError>}
+        {isInFuture && <FormError>Die Endzeit darf nicht in der Zukunft liegen.</FormError>}
+
+        <SubmitButton
+          type="submit"
+          disabled={isInvalid}
+          loading={loading}
+          className="h-12"
+          variant="outline"
+        >
+          <Square className="h-5 w-5" />
+          Pause beenden
+        </SubmitButton>
+      </form>
+    </section>
+  );
+}

--- a/projects/web/src/components/features/breaks/LiveBreakPanel.tsx
+++ b/projects/web/src/components/features/breaks/LiveBreakPanel.tsx
@@ -1,25 +1,17 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { format } from 'date-fns';
 import { Square } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { FormError } from '@/components/ui/form-error';
 import { SubmitButton } from '@/components/ui/submit-button';
-import { parseToTodayDate } from '@/lib/time';
+import { parseToTodayDate, isFutureTimeToday, formatBreakDuration } from '@/lib/time';
+import { useElapsedMinutes } from '@/hooks/useElapsedMinutes';
 
 interface LiveBreakPanelProps {
   liveBreakStart: Date;
   workdayStartTime: Date;
   onEnd: (endTime: Date) => Promise<void>;
-}
-
-function useElapsedMinutes(since: Date): number {
-  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - since.getTime()) / 60000));
-  useEffect(() => {
-    const id = setInterval(() => setElapsed(Math.floor((Date.now() - since.getTime()) / 60000)), 1000);
-    return () => clearInterval(id);
-  }, [since]);
-  return elapsed;
 }
 
 export function LiveBreakPanel({ liveBreakStart, workdayStartTime, onEnd }: LiveBreakPanelProps) {
@@ -28,16 +20,10 @@ export function LiveBreakPanel({ liveBreakStart, workdayStartTime, onEnd }: Live
   const elapsedMin = useElapsedMinutes(liveBreakStart);
 
   const parsedEnd = endStr ? parseToTodayDate(endStr) : null;
-  const isBeforeStart = !!(parsedEnd && parsedEnd <= liveBreakStart);
+  const isBeforeStart  = !!(parsedEnd && parsedEnd <= liveBreakStart);
   const isBeforeWorkday = !!(parsedEnd && parsedEnd < workdayStartTime);
-  const isInFuture = !!(parsedEnd && parsedEnd > new Date());
+  const isInFuture = isFutureTimeToday(endStr);
   const isInvalid = !endStr || isBeforeStart || isBeforeWorkday || isInFuture;
-
-  const h = Math.floor(elapsedMin / 60);
-  const m = elapsedMin % 60;
-  const durationText = h > 0
-    ? `${h}:${String(m).padStart(2, '0')} Std.`
-    : `${m} Min.`;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -64,7 +50,7 @@ export function LiveBreakPanel({ liveBreakStart, workdayStartTime, onEnd }: Live
             <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-orange-500" />
           </span>
           <span className="text-sm font-medium">
-            Seit {format(liveBreakStart, 'HH:mm')} – {durationText}
+            Seit {format(liveBreakStart, 'HH:mm')} – {formatBreakDuration(elapsedMin)}
           </span>
         </div>
       </div>
@@ -81,9 +67,9 @@ export function LiveBreakPanel({ liveBreakStart, workdayStartTime, onEnd }: Live
           />
         </div>
 
-        {isBeforeStart && <FormError>Endzeit muss nach {format(liveBreakStart, 'HH:mm')} liegen.</FormError>}
+        {isBeforeStart   && <FormError>Endzeit muss nach {format(liveBreakStart, 'HH:mm')} liegen.</FormError>}
         {isBeforeWorkday && <FormError>Endzeit darf nicht vor Dienstbeginn liegen.</FormError>}
-        {isInFuture && <FormError>Die Endzeit darf nicht in der Zukunft liegen.</FormError>}
+        {isInFuture      && <FormError>Die Endzeit darf nicht in der Zukunft liegen.</FormError>}
 
         <SubmitButton
           type="submit"

--- a/projects/web/src/components/features/breaks/StartBreakForm.tsx
+++ b/projects/web/src/components/features/breaks/StartBreakForm.tsx
@@ -1,0 +1,69 @@
+import { useState, type FormEvent } from 'react';
+import { format } from 'date-fns';
+import { Play } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { FormError } from '@/components/ui/form-error';
+import { SubmitButton } from '@/components/ui/submit-button';
+import { parseToTodayDate } from '@/lib/time';
+
+interface StartBreakFormProps {
+  workdayStartTime: Date;
+  onStart: (startTime: Date) => Promise<void>;
+}
+
+export function StartBreakForm({ workdayStartTime, onStart }: StartBreakFormProps) {
+  const [startStr, setStartStr] = useState(format(new Date(), 'HH:mm'));
+  const [loading, setLoading] = useState(false);
+
+  const parsedStart = startStr ? parseToTodayDate(startStr) : null;
+  const isBeforeWorkday = !!(parsedStart && parsedStart < workdayStartTime);
+  const isInFuture = !!(parsedStart && parsedStart > new Date());
+  const isInvalid = !startStr || isBeforeWorkday || isInFuture;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isInvalid || loading || !parsedStart) return;
+
+    setLoading(true);
+    try {
+      await onStart(parsedStart);
+    } catch (error) {
+      console.error('Start live break error:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <Eyebrow as="h3">Pause starten</Eyebrow>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium pl-1">Begonnen um</label>
+          <Input
+            type="time"
+            value={startStr}
+            onChange={e => setStartStr(e.target.value)}
+            required
+            className="h-12 text-lg text-center font-mono px-1"
+          />
+        </div>
+
+        {isBeforeWorkday && <FormError>Pause kann nicht vor Dienstbeginn ({format(workdayStartTime, 'HH:mm')}) liegen.</FormError>}
+        {isInFuture && <FormError>Die Startzeit darf nicht in der Zukunft liegen.</FormError>}
+
+        <SubmitButton
+          type="submit"
+          disabled={isInvalid}
+          loading={loading}
+          className="h-12"
+        >
+          <Play className="h-5 w-5" />
+          Pause starten
+        </SubmitButton>
+      </form>
+    </section>
+  );
+}

--- a/projects/web/src/components/features/breaks/StartBreakForm.tsx
+++ b/projects/web/src/components/features/breaks/StartBreakForm.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { FormError } from '@/components/ui/form-error';
 import { SubmitButton } from '@/components/ui/submit-button';
-import { parseToTodayDate } from '@/lib/time';
+import { parseToTodayDate, isFutureTimeToday } from '@/lib/time';
 
 interface StartBreakFormProps {
   workdayStartTime: Date;
@@ -18,7 +18,7 @@ export function StartBreakForm({ workdayStartTime, onStart }: StartBreakFormProp
 
   const parsedStart = startStr ? parseToTodayDate(startStr) : null;
   const isBeforeWorkday = !!(parsedStart && parsedStart < workdayStartTime);
-  const isInFuture = !!(parsedStart && parsedStart > new Date());
+  const isInFuture = isFutureTimeToday(startStr);
   const isInvalid = !startStr || isBeforeWorkday || isInFuture;
 
   const handleSubmit = async (e: FormEvent) => {

--- a/projects/web/src/components/features/timer/DisplayScreen.tsx
+++ b/projects/web/src/components/features/timer/DisplayScreen.tsx
@@ -10,9 +10,10 @@ interface DisplayScreenProps {
   startTime: Date;
   breaks: BreakRecord[];
   maxOvertimeMinutes?: number | null;
+  liveBreakStart?: Date | null;
 }
 
-export function DisplayScreen({ startTime, breaks, maxOvertimeMinutes }: DisplayScreenProps) {
+export function DisplayScreen({ startTime, breaks, maxOvertimeMinutes, liveBreakStart }: DisplayScreenProps) {
   const {
     manualBreaksMin,
     appliedBreaksMin,
@@ -30,7 +31,7 @@ export function DisplayScreen({ startTime, breaks, maxOvertimeMinutes }: Display
     isOvertime,
     workdayMsg,
     grossMin,
-  } = useTimerCalculations(startTime, breaks, maxOvertimeMinutes);
+  } = useTimerCalculations(startTime, breaks, maxOvertimeMinutes, liveBreakStart);
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-6 w-full px-5 py-6 animate-in fade-in duration-700">

--- a/projects/web/src/components/features/timer/workdayStatus.ts
+++ b/projects/web/src/components/features/timer/workdayStatus.ts
@@ -11,7 +11,9 @@ import {
   WORKDAY_FEIERABEND_NEAR_MINUTES,
   WORKDAY_SOLL_REACHED_MINUTES,
   WORKDAY_OVERTIME_STRONG_MINUTES,
+  calculateElapsedMinutes,
 } from '@figo/shared';
+import { formatBreakDuration } from '@/lib/time';
 
 export type WorkdayMessageSeverity = 'urgent' | 'warning' | 'success' | 'info';
 
@@ -32,10 +34,8 @@ export interface WorkdayMessageParams {
   minutesToDailyMax?: number | null;
   /** True when the daily maximum falls before the 10h legal limit (i.e. is actually restrictive). */
   dailyMaxBeforeTenHours?: boolean;
-  /** True while an open (live) break is actively running. */
-  liveBreakRunning?: boolean;
-  /** Elapsed minutes of the currently running live break. */
-  liveBreakMin?: number;
+  /** Start time of the currently running live break, or null if none. */
+  liveBreakStart?: Date | null;
 }
 
 function pad(n: number): string {
@@ -68,8 +68,7 @@ export function getWorkdayMessage({
   nextLegalPauseDeduction,
   minutesToDailyMax,
   dailyMaxBeforeTenHours,
-  liveBreakRunning,
-  liveBreakMin = 0,
+  liveBreakStart,
 }: WorkdayMessageParams): WorkdayMessage | null {
   const nowMin              = toNowMin(currentTime);
   const minutesToTen        = MAX_WORK_LIMIT_MINUTES - workedMinutes;
@@ -129,14 +128,9 @@ export function getWorkdayMessage({
   }
 
   // Open (live) break is running — suppress time-limit approach warnings
-  if (liveBreakRunning) {
-    const h = Math.floor(liveBreakMin / 60);
-    const m = liveBreakMin % 60;
-    const durationText = h > 0
-      ? `${h}:${String(m).padStart(2, '0')} Std.`
-      : `${m} Min.`;
+  if (liveBreakStart) {
     return {
-      text: `Pause läuft – seit ${durationText}`,
+      text: `Pause läuft – seit ${formatBreakDuration(calculateElapsedMinutes(liveBreakStart))}`,
       severity: 'warning',
     };
   }

--- a/projects/web/src/components/features/timer/workdayStatus.ts
+++ b/projects/web/src/components/features/timer/workdayStatus.ts
@@ -32,6 +32,10 @@ export interface WorkdayMessageParams {
   minutesToDailyMax?: number | null;
   /** True when the daily maximum falls before the 10h legal limit (i.e. is actually restrictive). */
   dailyMaxBeforeTenHours?: boolean;
+  /** True while an open (live) break is actively running. */
+  liveBreakRunning?: boolean;
+  /** Elapsed minutes of the currently running live break. */
+  liveBreakMin?: number;
 }
 
 function pad(n: number): string {
@@ -64,6 +68,8 @@ export function getWorkdayMessage({
   nextLegalPauseDeduction,
   minutesToDailyMax,
   dailyMaxBeforeTenHours,
+  liveBreakRunning,
+  liveBreakMin = 0,
 }: WorkdayMessageParams): WorkdayMessage | null {
   const nowMin              = toNowMin(currentTime);
   const minutesToTen        = MAX_WORK_LIMIT_MINUTES - workedMinutes;
@@ -119,6 +125,19 @@ export function getWorkdayMessage({
     return {
       text: `Pausenabzug läuft – noch ${legalPauseMinsRemaining} Min.`,
       severity: 'urgent',
+    };
+  }
+
+  // Open (live) break is running — suppress time-limit approach warnings
+  if (liveBreakRunning) {
+    const h = Math.floor(liveBreakMin / 60);
+    const m = liveBreakMin % 60;
+    const durationText = h > 0
+      ? `${h}:${String(m).padStart(2, '0')} Std.`
+      : `${m} Min.`;
+    return {
+      text: `Pause läuft – seit ${durationText}`,
+      severity: 'warning',
     };
   }
 

--- a/projects/web/src/hooks/useElapsedMinutes.ts
+++ b/projects/web/src/hooks/useElapsedMinutes.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+import { calculateElapsedMinutes } from '@figo/shared';
+
+/** Ticks every second and returns the elapsed minutes since `since`. */
+export function useElapsedMinutes(since: Date): number {
+  const [elapsed, setElapsed] = useState(() => calculateElapsedMinutes(since));
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(calculateElapsedMinutes(since)), 1000);
+    return () => clearInterval(id);
+  }, [since]);
+  return elapsed;
+}

--- a/projects/web/src/hooks/useSessionData.ts
+++ b/projects/web/src/hooks/useSessionData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ref, onValue, set, push, remove } from 'firebase/database';
+import { ref, onValue, set, push, remove, update } from 'firebase/database';
 import { db } from '../config/firebase';
 import { useAuth } from './useAuth';
 import { isToday } from 'date-fns';
@@ -15,6 +15,7 @@ export interface SessionData {
   startTime: Date | null;
   breaks: FirebaseBreakRecord[];
   dailyMaxOvertimeMinutes: number | null;
+  liveBreakStart: Date | null;
   loading: boolean;
 }
 
@@ -25,6 +26,7 @@ export function useSessionData() {
     startTime: null,
     breaks: [],
     dailyMaxOvertimeMinutes: null,
+    liveBreakStart: null,
     loading: true
   });
 
@@ -38,6 +40,7 @@ export function useSessionData() {
       startTime: null,
       breaks: [],
       dailyMaxOvertimeMinutes: null,
+      liveBreakStart: null,
       loading: true
     });
 
@@ -51,6 +54,7 @@ export function useSessionData() {
         let startTime: Date | null = null;
         let breaks: FirebaseBreakRecord[] = [];
         let dailyMaxOvertimeMinutes: number | null = null;
+        let liveBreakStart: Date | null = null;
 
         if (val) {
           // Parse Start Time
@@ -86,12 +90,18 @@ export function useSessionData() {
           if (typeof val.dailyMaxOvertimeMinutes === 'number' && startTime) {
             dailyMaxOvertimeMinutes = val.dailyMaxOvertimeMinutes;
           }
+
+          // Parse live break start
+          if (typeof val.liveBreakStart === 'number' && startTime) {
+            liveBreakStart = new Date(val.liveBreakStart);
+          }
         }
 
         setData({
           startTime,
           breaks,
           dailyMaxOvertimeMinutes,
+          liveBreakStart,
           loading: false
         });
       },
@@ -171,6 +181,56 @@ export function useSessionData() {
     }
   };
 
+  const startLiveBreak = async (startTime: Date) => {
+    if (!user) return;
+    try {
+      const liveRef = ref(db, `data/${user.uid}/liveBreakStart`);
+      await set(liveRef, startTime.getTime());
+    } catch (error) {
+      console.error('Start live break error:', error);
+      toast({
+        title: 'Fehler beim Starten der Pause',
+        description: 'Bitte versuche es erneut.',
+        variant: 'destructive'
+      });
+    }
+  };
+
+  const endLiveBreak = async (endTime: Date) => {
+    if (!user || !data.liveBreakStart) return;
+    const breakStart = data.liveBreakStart;
+
+    // Discard sub-second or zero-length breaks
+    if (endTime.getTime() - breakStart.getTime() < 1000) {
+      await remove(ref(db, `data/${user.uid}/liveBreakStart`));
+      return;
+    }
+
+    // Generate a new push key for the completed break record
+    const newBreakRef = push(ref(db, `data/${user.uid}/breaks`));
+    const newBreakKey = newBreakRef.key!;
+
+    // Atomic multi-path write: add completed break + clear liveBreakStart in one operation
+    const updates: Record<string, unknown> = {
+      [`data/${user.uid}/breaks/${newBreakKey}`]: {
+        start: breakStart.getTime(),
+        end:   endTime.getTime(),
+      },
+      [`data/${user.uid}/liveBreakStart`]: null,
+    };
+
+    try {
+      await update(ref(db), updates);
+    } catch (error) {
+      console.error('End live break error:', error);
+      toast({
+        title: 'Fehler beim Beenden der Pause',
+        description: 'Bitte versuche es erneut.',
+        variant: 'destructive'
+      });
+    }
+  };
+
   const setDailyMaxOvertime = async (v: number | null) => {
     if (!user) return;
     try {
@@ -197,5 +257,7 @@ export function useSessionData() {
     addBreak,
     removeBreak,
     setDailyMaxOvertime,
+    startLiveBreak,
+    endLiveBreak,
   };
 }

--- a/projects/web/src/hooks/useTimerCalculations.ts
+++ b/projects/web/src/hooks/useTimerCalculations.ts
@@ -166,9 +166,6 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
 
   // Kontextuelle Statusnachricht
   const legalPauseStatus = calculateLegalPauseStatus(grossMin, manualBreaksMin);
-  const liveBreakMin = liveBreakStart
-    ? Math.floor((now.getTime() - liveBreakStart.getTime()) / 60000)
-    : 0;
   const workdayMsg = getWorkdayMessage({
     currentTime:             now,
     sollMinutes:             WORK_TIME_TARGET_MINUTES,
@@ -179,8 +176,7 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
     nextLegalPauseDeduction: legalPauseStatus.nextPauseDeduction,
     minutesToDailyMax,
     dailyMaxBeforeTenHours:  maxOvertimeMinutes != null && (WORK_TIME_TARGET_MINUTES + maxOvertimeMinutes) < MAX_WORK_LIMIT_MINUTES,
-    liveBreakRunning:        liveBreakStart != null,
-    liveBreakMin,
+    liveBreakStart:          liveBreakStart ?? null,
   });
 
   return {

--- a/projects/web/src/hooks/useTimerCalculations.ts
+++ b/projects/web/src/hooks/useTimerCalculations.ts
@@ -58,7 +58,7 @@ export interface TimerCalculations {
  * abgeleiteten Zustand für den Timer-Ring (Segmente, Winkel, Saldo,
  * kontextuelle Nachricht). Reine Berechnung, keine Darstellung.
  */
-export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], maxOvertimeMinutes?: number | null): TimerCalculations {
+export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], maxOvertimeMinutes?: number | null, liveBreakStart?: Date | null): TimerCalculations {
   const [now, setNow] = useState(new Date());
 
   useEffect(() => {
@@ -68,7 +68,7 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
 
   // ── Grundgrößen ───────────────────────────────────────────────────────
   const grossMin         = calculateGrossWorkTimeMinutes(startTime, now);
-  const manualBreaksMin  = calculateManualBreaksMinutes(breaks);
+  const manualBreaksMin  = calculateManualBreaksMinutes(breaks, liveBreakStart ?? null, now);
   const appliedBreaksMin = calculateAppliedBreakMinutes(grossMin, manualBreaksMin);
   const netMin           = calculateNetWorkTimeMinutes(grossMin, appliedBreaksMin);
   const saldoMin         = calculateSaldoMinutes(netMin);
@@ -83,12 +83,19 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
   const ringMaxMin       = tenGross;
 
   // ── Pausen-Intervalle auf dem Ring ────────────────────────────────────
-  const manualIntervals: Interval[] = breaks
-    .map(b => ({
-      start: Math.max(0, (b.start.getTime() - startTime.getTime()) / 60000),
-      end:   Math.max(0, (b.end.getTime()   - startTime.getTime()) / 60000),
-    }))
-    .filter(m => m.end > m.start);
+  const manualIntervals: Interval[] = [
+    ...breaks
+      .map(b => ({
+        start: Math.max(0, (b.start.getTime() - startTime.getTime()) / 60000),
+        end:   Math.max(0, (b.end.getTime()   - startTime.getTime()) / 60000),
+      }))
+      .filter(m => m.end > m.start),
+    // Live break: grows every second because `now` ticks
+    ...(liveBreakStart ? [{
+      start: Math.max(0, (liveBreakStart.getTime() - startTime.getTime()) / 60000),
+      end:   Math.max(0, (now.getTime() - startTime.getTime()) / 60000),
+    }] : []),
+  ];
 
   const [zone1, zone2]   = calculateLegalPauseZones(grossMin, manualBreaksMin);
   const zone1HintSlots   = placeInZone(zone1.startMin, zone1.endMin, zone1.potentialMin, manualIntervals);
@@ -117,6 +124,14 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
         wallEnd:   b.end,
       }))
       .filter(m => m.end > m.start),
+    // Live break hover item
+    ...(liveBreakStart ? [{
+      start:     Math.max(0, (liveBreakStart.getTime() - startTime.getTime()) / 60000),
+      end:       Math.max(0, (now.getTime() - startTime.getTime()) / 60000),
+      kind:      'manual' as const,
+      wallStart: liveBreakStart,
+      wallEnd:   now,
+    }] : []),
     ...hintSlots.map(iv => ({
       ...iv,
       kind:      'legal' as const,
@@ -151,6 +166,9 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
 
   // Kontextuelle Statusnachricht
   const legalPauseStatus = calculateLegalPauseStatus(grossMin, manualBreaksMin);
+  const liveBreakMin = liveBreakStart
+    ? Math.floor((now.getTime() - liveBreakStart.getTime()) / 60000)
+    : 0;
   const workdayMsg = getWorkdayMessage({
     currentTime:             now,
     sollMinutes:             WORK_TIME_TARGET_MINUTES,
@@ -161,6 +179,8 @@ export function useTimerCalculations(startTime: Date, breaks: BreakRecord[], max
     nextLegalPauseDeduction: legalPauseStatus.nextPauseDeduction,
     minutesToDailyMax,
     dailyMaxBeforeTenHours:  maxOvertimeMinutes != null && (WORK_TIME_TARGET_MINUTES + maxOvertimeMinutes) < MAX_WORK_LIMIT_MINUTES,
+    liveBreakRunning:        liveBreakStart != null,
+    liveBreakMin,
   });
 
   return {

--- a/projects/web/src/lib/firebase-actions.ts
+++ b/projects/web/src/lib/firebase-actions.ts
@@ -12,6 +12,7 @@ export async function resetWorkSession(uid: string) {
     [`data/${uid}/startTime`]:               null,
     [`data/${uid}/breaks`]:                  null,
     [`data/${uid}/dailyMaxOvertimeMinutes`]:  null,
+    [`data/${uid}/liveBreakStart`]:           null,
   };
 
   try {

--- a/projects/web/src/lib/time.ts
+++ b/projects/web/src/lib/time.ts
@@ -14,3 +14,10 @@ export function isFutureTimeToday(timeStr: string): boolean {
   if (!timeStr) return false;
   return parseToTodayDate(timeStr) > new Date();
 }
+
+/** Formatiert eine Dauer in Minuten als "H:MM Std." (>= 60 min) oder "M Min." */
+export function formatBreakDuration(totalMinutes: number): string {
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return h > 0 ? `${h}:${String(m).padStart(2, '0')} Std.` : `${m} Min.`;
+}


### PR DESCRIPTION
Nutzer können jetzt eine Pause starten ohne das Ende zu kennen. Die
Pause läuft vom gewählten Startzeitpunkt bis zum expliziten Beenden.
Start- und Endzeit sind editierbar (Nachtragen aus Primärtool möglich).

Während der laufenden Pause:
- Netto-Arbeitszeit wächst nicht
- Geplantes Feierabend- und 10h-Limit verschieben sich live
- Keine Push-Benachrichtigungen über Zeitgrenzen
- Statusmeldung zeigt "Pause läuft – seit X Min."
- BreaksTrigger zeigt Puls-Indikator

Änderungen:
- shared/breaks: calculateManualBreaksMinutes um liveBreakStart erweiterbar
- functions/index: liveBreakStart-Guard vor Notification-Planung
- firebase-actions: liveBreakStart beim Ausstempeln löschen
- useSessionData: liveBreakStart State + startLiveBreak/endLiveBreak
- useTimerCalculations: liveBreakStart in alle Berechnungen einbeziehen
- workdayStatus: neue Prioritätsregel für laufende Pause
- BreaksDrawer: StartBreakForm / LiveBreakPanel je nach Zustand
- StartBreakForm: neue Komponente mit editierbarer Startzeit
- LiveBreakPanel: neue Komponente mit Laufzeitanzeige + editierbarer Endzeit

https://claude.ai/code/session_0171RYDHZMKZ7x63dnuBoQkg