### PR TITLE
Switch push notifications to data-only payload format

### DIFF
--- a/projects/functions/src/index.ts
+++ b/projects/functions/src/index.ts
@@ -173,8 +173,16 @@ export const onSendPushNotification = onTaskDispatched<PushPayload>(
       payload.type === 'DAILY_MAX' ? 'Zeit, Feierabend zu machen – dein heutiges Arbeitszeit-Maximum ist erreicht.' :
       'Du hast deine 10-Stunden-Grenze erreicht! Bitte stempeln.';
 
+    // Data-only payload: prevents FCM SDK from auto-displaying the notification
+    // in the service worker, which would duplicate the manual showNotification()
+    // call in onBackgroundMessage.
     const message = {
-      notification: { title, body },
+      data: {
+        type: payload.type,
+        title,
+        body,
+        url: FCM_LINK,
+      },
       webpush: {
         fcmOptions: { link: FCM_LINK },
       },

--- a/projects/web/src/hooks/push/usePushSubscription.ts
+++ b/projects/web/src/hooks/push/usePushSubscription.ts
@@ -155,9 +155,9 @@ export function usePushSubscription({
       if (!messaging) return;
       unsubscribe = onMessage(messaging, (payload) => {
         console.debug('[PushNotifications] Foreground message:', payload);
-        if (Notification.permission === 'granted' && payload.notification) {
-          new Notification(payload.notification.title || 'fi-go', {
-            body: payload.notification.body,
+        if (Notification.permission === 'granted' && payload.data) {
+          new Notification(payload.data.title || 'fi-go', {
+            body: payload.data.body,
             icon: '/icon-192x192.png',
           });
         }

--- a/projects/web/src/sw.ts
+++ b/projects/web/src/sw.ts
@@ -21,14 +21,14 @@ const messaging = getMessaging(app);
 onBackgroundMessage(messaging, (payload) => {
   console.debug('[sw.ts] Received background message:', payload);
 
-  const notificationTitle = payload.notification?.title || 'fi-go';
+  const notificationTitle = payload.data?.title || 'fi-go';
   const notificationOptions = {
-    body: payload.notification?.body || '',
+    body: payload.data?.body || '',
     icon: '/icon-192x192.png',
     badge: '/icon-192x192.png',
     data: {
       ...payload.data,
-      url: payload.fcmOptions?.link || self.registration.scope,
+      url: payload.data?.url || payload.fcmOptions?.link || self.registration.scope,
     },
   };
 


### PR DESCRIPTION
## Summary
Refactored push notification handling to use FCM data-only payloads instead of the notification field. This prevents the FCM SDK from automatically displaying notifications in the service worker, eliminating duplicate notifications when combined with manual `showNotification()` calls.

## Key Changes
- **Backend (functions)**: Changed FCM message format from `notification` field to `data` field, moving title, body, and URL into the data payload with explanatory comments
- **Foreground handler (usePushSubscription)**: Updated to read notification content from `payload.data` instead of `payload.notification`
- **Background handler (sw.ts)**: Updated to extract notification title and body from `payload.data`, and prioritize the URL from data payload over fcmOptions

## Implementation Details
- The data-only approach gives the application full control over notification display across both foreground and background contexts
- URL is now consistently passed through the data payload and used as the primary source in the service worker
- Fallback logic preserved for graceful degradation (e.g., 'fi-go' default title)

https://claude.ai/code/session_01XsXGmkRqpMuE9cJer1ju4n